### PR TITLE
SitePro Fix

### DIFF
--- a/app/controllers/U.php
+++ b/app/controllers/U.php
@@ -1143,7 +1143,7 @@ class U extends CI_Controller
 					$domain = $this->input->get('domain');
 					if($domain !== $res['account_domain'])
 					{
-						$dir = '/htdocs/'.$domain;
+						$dir = '/'.$domain.'/htdocs/';
 					}
 					else
 					{


### PR DESCRIPTION
Fixed SitePro from creating a website in the wrong directory, when using a domain other than the Account Domain. Previously it was created at /htdocs/domain
When it should be at /domain/htdocs instead