### PR TITLE
Bug Fixes and a little improvements

### DIFF
--- a/template/default/page/admin/dashboard.php
+++ b/template/default/page/admin/dashboard.php
@@ -23,7 +23,7 @@
 								Registered Clients
 							</div>
 							<div class="text-muted">
-								<?= $ci_clients ?> in total
+								<?= $this->user->get_count('active') + $this->user->get_count('inactive') ?> in total
 							</div>
 						</div>
 					</div>
@@ -45,7 +45,7 @@
 								Hosting Accounts
 							</div>
 							<div class="text-muted">
-								<?= $ci_accounts ?> in total
+								<?= $this->account->get_count('active') + $this->account->get_count('suspended') + $this->account->get_count('deactivated') ?> in total
 							</div>
 						</div>
 					</div>
@@ -277,7 +277,7 @@
 		}]
 	};
 	var options1 = {
-		series: [<?= $this->account->get_count('active'); ?>, <?= $this->user->get_count('suspended') + $this->user->get_count('deactivated'); ?>],
+		series: [<?= $this->account->get_count('active'); ?>, <?= $this->account->get_count('suspended') + $this->account->get_count('deactivated'); ?>],
 		chart: {
 			type: 'donut'
 		},


### PR DESCRIPTION
Fixed some database typos and the donut chart of Hosting Accounts! Now, when the records per page is set lower than the all total count of any data, the total one shows all the count, instead of showing the records per page count. The Donut chart of hosting accounts had typos like on place of retrieving accounts from the database, it was getting users. Now the chart works fine.