### PR TITLE
Fix for SMTP Encryption and SSL auto generate CSR

### DIFF
--- a/app/controllers/A.php
+++ b/app/controllers/A.php
@@ -582,6 +582,7 @@ class A extends CI_Controller
 				$this->fv->set_rules('password', 'Password', ['trim', 'required']);
 				$this->fv->set_rules('port', 'Port', ['trim', 'required']);
 				$this->fv->set_rules('status', 'Status', ['trim', 'required']);
+				$this->fv->set_rules('encryption', 'SMTP Encryption', ['trim', 'required']);
 				if($this->fv->run() === true)
 				{
 					$hostname = $this->input->post('hostname');
@@ -590,6 +591,7 @@ class A extends CI_Controller
 					$username = $this->input->post('username');
 					$port = $this->input->post('port');
 					$status = $this->input->post('status');
+					$encryption = $this->input->post('encryption');
 					$password = $this->input->post('password');
 					$res = $this->smtp->set_hostname($hostname);
 					$res = $this->smtp->set_username($username);
@@ -598,6 +600,7 @@ class A extends CI_Controller
 					$res = $this->smtp->set_from($from);
 					$res = $this->smtp->set_name($name);
 					$res = $this->smtp->set_port($port);
+					$res = $this->smtp->set_encryption($encryption);
 					if($res !== false)
 					{
 						$this->session->set_flashdata('msg', json_encode([1, 'SMTP settings updated successfully.']));

--- a/app/controllers/U.php
+++ b/app/controllers/U.php
@@ -1426,7 +1426,7 @@ class U extends CI_Controller
 		{
 			if($this->input->post('create'))
 			{
-				$this->fv->set_rules('csr', $this->base->text('csr_code', 'label'), ['trim', 'required']);
+				$this->fv->set_rules('domain', $this->base->text('domain_name', 'label'), ['trim', 'required']);
 				if($this->grc->is_active())
 				{
 					if($this->grc->get_type() == "google")
@@ -1443,7 +1443,7 @@ class U extends CI_Controller
 					}
 					if($this->fv->run() === true)
 					{
-						$csr = $this->input->post('csr');
+						$domain = $this->input->post('domain');
 						if($this->grc->get_type() == "google")
 						{
 							$token = $this->input->post('g-recaptcha-response');
@@ -1461,7 +1461,7 @@ class U extends CI_Controller
 						}
 						if($this->grc->is_valid($token, $type))
 						{
-							$res = $this->ssl->create_ssl($csr);
+							$res = $this->ssl->create_ssl($domain);
 							if(!is_bool($res))
 							{
 								$this->session->set_flashdata('msg', json_encode([0, $res]));

--- a/app/controllers/U.php
+++ b/app/controllers/U.php
@@ -1501,8 +1501,8 @@ class U extends CI_Controller
 				{
 					if($this->fv->run() === true)
 					{
-						$csr = $this->input->post('csr');
-						$res = $this->ssl->create_ssl($csr);
+						$domain = $this->input->post('domain');
+						$res = $this->ssl->create_ssl($domain);
 						if(!is_bool($res))
 						{
 							$this->session->set_flashdata('msg', json_encode([0, $res]));

--- a/app/language/Latvian/label_lang.php
+++ b/app/language/Latvian/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'Domēns';
 $lang['theme'] = 'Tēma';
 $lang['label'] = 'Marķējums';
 $lang['csr_code'] = 'CSR kods';
+$lang['private_key'] = 'Privātā atslēga';
 $lang['crt_code'] = 'CRT kods';
 $lang['ca_code'] = 'CA kods';
 $lang['reason'] = 'Iemesls';

--- a/app/language/Simplified-Chinese/label_lang.php
+++ b/app/language/Simplified-Chinese/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = '网域';
 $lang['theme'] = '主题';
 $lang['label'] = '标签';
 $lang['csr_code'] = 'CSR 代码';
+$lang['private_key'] = '私钥';
 $lang['crt_code'] = 'CRT 代码';
 $lang['ca_code'] = 'CA 代码';
 $lang['reason'] = '原因';

--- a/app/language/Traditional-Chinese/label_lang.php
+++ b/app/language/Traditional-Chinese/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = '網域';
 $lang['theme'] = '主題';
 $lang['label'] = '標籤';
 $lang['csr_code'] = 'CSR 代碼';
+$lang['private_key'] = '私鑰';
 $lang['crt_code'] = 'CRT 代碼';
 $lang['ca_code'] = 'CA 代碼';
 $lang['reason'] = '原因';

--- a/app/language/english/label_lang.php
+++ b/app/language/english/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'Domain';
 $lang['theme'] = 'Theme';
 $lang['label'] = 'Label';
 $lang['csr_code'] = 'CSR Code';
+$lang['private_key'] = 'Private Key';
 $lang['crt_code'] = 'CRT Code';
 $lang['ca_code'] = 'CA Code';
 $lang['reason'] = 'Reason';

--- a/app/language/french/label_lang.php
+++ b/app/language/french/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'Domaine';
 $lang['theme'] = 'Thème';
 $lang['label'] = 'Étiquetteette';
 $lang['csr_code'] = 'Code CSR';
+$lang['private_key'] = 'Clé privée';
 $lang['crt_code'] = 'Code CRT';
 $lang['ca_code'] = 'Code CA';
 $lang['reason'] = 'Raison';

--- a/app/language/greek/label_lang.php
+++ b/app/language/greek/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'ΤΟΜΕΑΣ';
 $lang['theme'] = 'Θέμα';
 $lang['label'] = 'Ετικέτα';
 $lang['csr_code'] = 'Κώδικας CSR';
+$lang['private_key'] = 'Ιδιωτικό κλειδί';
 $lang['crt_code'] = 'Κώδικας CRT';
 $lang['ca_code'] = 'Κώδικας CA';
 $lang['reason'] = 'Αιτία (Προαιρετικά)';

--- a/app/language/italian/label_lang.php
+++ b/app/language/italian/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'Dominio';
 $lang['theme'] = 'Tema';
 $lang['label'] = 'Ettichetta';
 $lang['csr_code'] = 'Codice CSR';
+$lang['private_key'] = 'Chiave privata';
 $lang['crt_code'] = 'Codice CRT';
 $lang['ca_code'] = 'Codice CA';
 $lang['reason'] = 'Motivazione';

--- a/app/language/norwegian/label_lang.php
+++ b/app/language/norwegian/label_lang.php
@@ -15,6 +15,7 @@ $lang['domain'] = 'Domene';
 $lang['theme'] = 'Tema';
 $lang['label'] = 'label';
 $lang['csr_code'] = 'CSR-kode';
+$lang['private_key'] = 'Privat nøkkel';
 $lang['crt_code'] = 'CRT-kode';
 $lang['ca_code'] = 'CA-kode';
 $lang['reason'] = 'Årsaken';

--- a/app/models/Mailer.php
+++ b/app/models/Mailer.php
@@ -7,11 +7,19 @@ class Mailer extends CI_Model
 		parent::__construct();
 		$this->load->model('smtp');
 		$this->load->library('email');
+ 	    $this->load->model('base');
+        $crypto = $this->smtp->get_encryption();
+        if ($crypto === 'none') {
+            $crypto = '';
+        }
 
 		$email['smtp_host'] = $this->smtp->get_hostname();
 		$email['smtp_user'] = $this->smtp->get_username();
 		$email['smtp_pass'] = $this->smtp->get_password();
 		$email['smtp_port'] = $this->smtp->get_port();
+        $email['smtp_crypto'] = $crypto;
+        $email['mailtype'] = 'html';
+        $email['newline'] = '\r\n';
 
 		$this->email->initialize($email);
 	}

--- a/app/models/Smtp.php
+++ b/app/models/Smtp.php
@@ -126,6 +126,16 @@ class Smtp extends CI_Model
 		return false;
 	}
 
+    function get_encryption()
+	{
+		$res = $this->fetch();
+		if($res !== false)
+		{
+			return $res['smtp_encryption'];
+		}
+		return false;
+	}
+
 	function set_status(bool $status)
 	{
 		if($status === true)
@@ -140,6 +150,19 @@ class Smtp extends CI_Model
 		if($res)
 		{
 			return true;
+		}
+		return false;
+	}
+ 
+    function set_encryption(string $encryption)
+	{
+		if($encryption === 'tls' || $encryption === 'ssl' || $encryption === 'none')
+		{ 
+			$res = $this->update('encryption', $encryption);
+		    if($res)
+		    {
+		    	return true;
+		    }
 		}
 		return false;
 	}

--- a/app/models/Ticket.php
+++ b/app/models/Ticket.php
@@ -110,6 +110,15 @@ class Ticket extends CI_Model
 		return false;
 	}
 
+    function get_status($id) {
+        $res = $this->fetch('is_ticket', ['key' => $id]);
+		if(count($res)>0)
+		{
+			return $res[0]['ticket_status'];
+		}
+		return false;
+    }
+
 	function add_reply($id, $content, $by, $status)
 	{
 		$data['reply_content'] = $content;
@@ -120,33 +129,37 @@ class Ticket extends CI_Model
 		$data['ticket_key'] = $id;
 		if($res !== false)
 		{
-			$res = $this->change_ticket_status($id, $status);
-			if($res !== false)
-			{
-				if($this->mailer->is_active())
-				{
-					if($this->get_user_name($by) !== false)
-					{
-						$param['admin_name'] = $this->base->get_hostname();
-						$email = $this->base->get_email();
-						$tpl = 'admin';
-						$param['ticket_url'] = base_url().'admin/ticket/view/'.$data['ticket_key'];
-					}
-					else
-					{
-						$except_key = $this->fetch_user_except($by, $id);
-						$param['user_name'] = $this->get_user_name($except_key);
-						$email = $this->get_user_email($except_key);
-						$tpl = 'user';
-						$param['ticket_url'] = base_url().'ticket/view/'.$data['ticket_key'];
-					}
-					$param['ticket_id'] = $data['ticket_key'];
-					$this->mailer->send('reply_ticket', $email, $param, $tpl);
-					return true;
-				}
-				return true;
-			}
-			return false;
+            if ($this->get_status($id) != $status) {
+			    $res = $this->change_ticket_status($id, $status);
+            } else {
+                $res = true;
+            }
+			    if($res !== false)
+			    {
+			    	if($this->mailer->is_active())
+			    	{
+			    		if($this->get_user_name($by) !== false)
+			    		{
+			    			$param['admin_name'] = $this->base->get_hostname();
+			    			$email = $this->base->get_email();
+			    			$tpl = 'admin';
+			    			$param['ticket_url'] = base_url().'admin/ticket/view/'.$data['ticket_key'];
+			    		}
+			    		else
+			    		{
+			    			$except_key = $this->fetch_user_except($by, $id);
+			    			$param['user_name'] = $this->get_user_name($except_key);
+			    			$email = $this->get_user_email($except_key);
+			    			$tpl = 'user';
+			    			$param['ticket_url'] = base_url().'ticket/view/'.$data['ticket_key'];
+			    		}
+			    		$param['ticket_id'] = $data['ticket_key'];
+			    		$this->mailer->send('reply_ticket', $email, $param, $tpl);
+			    		return true;
+			    	}
+			    	return true;
+			    }
+			    return false;
 		}
 		return false;
 	}

--- a/db.sql
+++ b/db.sql
@@ -70,7 +70,8 @@ CREATE TABLE `is_smtp` (
 	`smtp_port` varchar(8) NOT NULL,
 	`smtp_from` varchar(100) NOT NULL,
 	`smtp_status` varchar(8) NOT NULL,
-	`smtp_name` varchar(50) NOT NULL
+	`smtp_name` varchar(50) NOT NULL,
+	`smtp_encryption` varchar(5) NOT NULL
 );
 
 -- Insert default record for `is_smtp`

--- a/db.sql
+++ b/db.sql
@@ -476,7 +476,8 @@ CREATE TABLE `is_ssl` (
 	`ssl_id` int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	`ssl_pid` varchar(250) NOT NULL,
 	`ssl_key` varchar(20) NOT NULL,
-	`ssl_for` varchar(20) NOT NULL
+	`ssl_for` varchar(20) NOT NULL,
+	`ssl_private` varchar(5000) NOT NULL
 );
 
 -- Create new table `is_oauth`

--- a/install.php
+++ b/install.php
@@ -184,11 +184,11 @@ if (isset($_GET['step']) and $_GET['step'] == 1 and isset($_POST['submit'])) {
 
 		$sql = mysqli_query($mysqli, "DROP TABLE IF EXISTS `is_smtp`;");
 
-		$sql = mysqli_query($mysqli, "CREATE TABLE `is_smtp` (`smtp_id` varchar(9) NOT NULL DEFAULT 'xera_smtp',`smtp_hostname` varchar(100) NOT NULL,`smtp_username` varchar(100) NOT NULL,`smtp_password` varchar(100) NOT NULL,`smtp_port` varchar(8) NOT NULL,`smtp_from` varchar(100) NOT NULL,`smtp_status` varchar(8) NOT NULL,`smtp_name` varchar(50) NOT NULL
+		$sql = mysqli_query($mysqli, "CREATE TABLE `is_smtp` (`smtp_id` varchar(9) NOT NULL DEFAULT 'xera_smtp',`smtp_hostname` varchar(100) NOT NULL,`smtp_username` varchar(100) NOT NULL,`smtp_password` varchar(100) NOT NULL,`smtp_port` varchar(8) NOT NULL,`smtp_from` varchar(100) NOT NULL,`smtp_status` varchar(8) NOT NULL,`smtp_name` varchar(50) NOT NULL, `smtp_encryption` varchar(5) NOT NULL
 		);");
 
-		$sql = mysqli_query($mysqli, "INSERT INTO `is_smtp` (`smtp_id`,`smtp_hostname`,`smtp_username`,`smtp_password`,`smtp_port`,`smtp_from`,`smtp_status`,`smtp_name`
-		) VALUES ('xera_smtp','smtp.example.com','username','password','587','jhon@example.com','inactive','Web Host'
+		$sql = mysqli_query($mysqli, "INSERT INTO `is_smtp` (`smtp_id`,`smtp_hostname`,`smtp_username`,`smtp_password`,`smtp_port`,`smtp_from`,`smtp_status`,`smtp_name`,`smtp_encryption`
+		) VALUES ('xera_smtp','smtp.example.com','username','password','587','jhon@example.com','inactive','Web Host','none'
 		);");
 
 		$sql = mysqli_query($mysqli, "DROP TABLE IF EXISTS `is_mofh`;");

--- a/install.php
+++ b/install.php
@@ -297,7 +297,7 @@ if (isset($_GET['step']) and $_GET['step'] == 1 and isset($_POST['submit'])) {
 
 		$sql = mysqli_query($mysqli, "DROP TABLE IF EXISTS `is_ssl`;");
 
-		$sql = mysqli_query($mysqli, "CREATE TABLE `is_ssl` (`ssl_id` int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,`ssl_pid` varchar(250) NOT NULL,`ssl_key` varchar(20) NOT NULL,`ssl_for` varchar(20) NOT NULL
+		$sql = mysqli_query($mysqli, "CREATE TABLE `is_ssl` (`ssl_id` int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,`ssl_pid` varchar(250) NOT NULL,`ssl_key` varchar(20) NOT NULL,`ssl_for` varchar(20) NOT NULL,`ssl_private` varchar(5000) NOT NULL
 		);");
 
 		$sql = mysqli_query($mysqli, "CREATE TABLE `is_oauth` (`oauth_id` varchar(20) NOT NULL, `oauth_client` varchar(100) NOT NULL, `oauth_secret` varchar(100) NOT NULL, `oauth_endpoint` varchar(100) NOT NULL, `oauth_status` varchar(8) NOT NULL);");

--- a/template/default/page/admin/api_settings.php
+++ b/template/default/page/admin/api_settings.php
@@ -179,6 +179,34 @@
 						<label class="form-label">SMTP Port</label>
 						<input type="number" name="port" class="form-control mb-2" value="<?= $this->smtp->get_port() ?>">
 					</div>
+                    <div class="col-sm-6">
+						<label class="form-label">SMTP Encryption</label>
+						<select class="form-control mb-2" name="encryption">
+							<?php
+							if ($this->smtp->get_encryption() === 'ssl') {
+							?>
+								<option value="ssl" selected="true">SSL</option>
+								<option value="tls">TLS</option>
+ 							    <option value="none">None</option>
+							<?php
+                            }
+							elseif ($this->smtp->get_encryption() === 'tls') {
+							?>
+								<option value="ssl">SSL</option>
+								<option value="tls" selected="true">TLS</option>
+ 							    <option value="none">None</option>
+  						    <?php
+                            }
+							elseif ($this->smtp->get_encryption() === 'none') {
+							?>
+								<option value="ssl">SSL</option>
+								<option value="tls">TLS</option>
+ 							    <option value="none" selected="true">None</option>
+							<?php
+							}
+							?>
+						</select>
+					</div>
 					<div class="col-sm-6">
 						<label class="form-label">SMTP Status</label>
 						<select class="form-control mb-2" name="status">

--- a/template/default/page/user/create_ssl.php
+++ b/template/default/page/user/create_ssl.php
@@ -6,12 +6,11 @@
 	</div>
 	<div class="card p-2 mb-3">
 		<div class="card-body">
-		<p> You can generate CSR and Private key from <a href="https://www.gogetssl.com/online-csr-generator/">Online CSR Generator</a>
 			<?= form_open('ssl/create') ?>
 				<div class="row">
 					<div class="col-sm-12 mb-2">
-						<label class="form-label"><?= $this->base->text('csr_code', 'label') ?></label>
-						<textarea class="form-control" name="csr" placeholder="<?= $this->base->text('csr_code', 'label') ?>" style="min-height: 250px;"></textarea>
+						<label class="form-label"><?= $this->base->text('domain_name', 'label') ?></label>
+						<input type="text" class="form-control" name="domain" placeholder="<?= $this->base->text('domain_name', 'label') ?>"/>
 					</div>
 					<?php if($this->grc->is_active()):?>
 						<div class="mb-2">

--- a/template/default/page/user/view_ssl.php
+++ b/template/default/page/user/view_ssl.php
@@ -88,6 +88,10 @@
 					<label class="form-label"><?= $this->base->text('csr_code', 'label') ?></label>
 					<textarea class="form-control" style="min-height: 200px;" readonly="true"><?= $data['csr_code'] ?></textarea>
 				</div>
+ 			    <div class="mb-3">
+					<label class="form-label"><?= $this->base->text('private_key', 'label') ?></label>
+					<textarea class="form-control" style="min-height: 200px;" readonly="true"><?= $data['private_key'] ?></textarea>
+				</div>
 				<div class="mb-3">
 					<label class="form-label"><?= $this->base->text('crt_code', 'label') ?></label>
 					<textarea class="form-control" style="min-height: 200px;" readonly="true"><?= $data['crt_code'] ?></textarea>


### PR DESCRIPTION
I added an option in the api settings to select the type of SMTP encryption (ssl, tls, or none) to avoid errors that occur when it is incorrectly set by default. Additionally, I implemented functionality to automatically generate the CSR (Certificate Signing Request) when requesting an SSL certificate.