### PR TITLE
Adding nameserver notice create_account.php

### DIFF
--- a/template/default/page/user/create_account.php
+++ b/template/default/page/user/create_account.php
@@ -50,6 +50,7 @@
 						<div class="tab-pane" id="customdomain">
 							<?= form_open('account/create') ?>
 								<div class="">
+									<div class="alert">Your domain must point to our nameservers <strong>ns1.byet.org</strong> &amp; <strong>ns2.byet.org</strong> before hosting it on our website.</div>
 									<div class="mb-2">
 										<input type="text" name="domain" class="form-control" placeholder="<?= $this->base->text('domain_name', 'label') ?>">
 									</div>


### PR DESCRIPTION
Adding a notice to the custom domain field to inform users about nameserver validity before adding their custom domain name, to prevent "Nameserver not valid" issues.